### PR TITLE
allow syntax to include folder/*

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -67,8 +67,12 @@ connection.onInitialize(
         const server = new BeancountLspServer(params, progress);
 
         server.register();
-
-        await server.init()
+        
+        try {
+            await server.init();
+        } catch(e) {
+            connection.window.showErrorMessage(e);
+        }
 
 
         return server.capabilities;


### PR DESCRIPTION
`beancount`, `fava` and the beancount plugin on VS Code allows syntax such as `include 2020_folder/*`. 
This PR attempts to allow the same syntax in the beancount language server.
Also throws an exception on the client side when the server fails to start to make errors visible.