### PR TITLE
fix: activate document formatting by default

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -43,9 +43,14 @@ pub fn capabilities() -> lsp::ServerCapabilities {
         Some(options)
     };
 
+    let document_formatting_provider = {
+        Some(lsp::OneOf::Left(true))
+    };
+
     lsp::ServerCapabilities {
         text_document_sync,
         completion_provider,
+        document_formatting_provider,
         ..Default::default()
     }
 }


### PR DESCRIPTION
I found that this lsp doesn't do formatting in my neovim. After some investigation, I found it's becase `document_formatting_provider` is disabled in `InitializeResult` replied to lsp client (Its default value is` None`). After this change, `document_formatting_provider` in `initializeResult` replied to client is `true`, so it works now.

PS: I'm not a native English speaker and I haven't learnt rust before, forgive me if my PR is unproper.