### PR TITLE
fix: handle tilde in journal_file

### DIFF
--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -18,7 +18,9 @@ impl Config {
     pub fn update(&mut self, json: serde_json::Value) -> Result<()> {
         let beancount_lsp_settings: BeancountLspOptions = serde_json::from_value(json).unwrap();
         if beancount_lsp_settings.journal_file.is_some() {
-            self.journal_root = Some(PathBuf::from(beancount_lsp_settings.journal_file.unwrap()));
+            self.journal_root = Some(PathBuf::from(
+                shellexpand::tilde(&beancount_lsp_settings.journal_file.unwrap()).as_ref(),
+            ));
         }
         Ok(())
     }


### PR DESCRIPTION
Using tilde in the configuration for journal_file caused a panic. Solve this by using `shellexpand::tilde`  when setting `journal_root`  

Error:
```
`thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ()', crates/lsp/src/server.rs:122:91`
```
Configuration:
```
lsp.configure('beancount', {
    init_options = {
        journal_file = "~/beancount/journal.beancount",
    }
})
```