### PR TITLE
chore: specify workspace resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "crates/lsp",
 ]
+resolver = "2"
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]


### PR DESCRIPTION
This addresses the following warning:
```
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```