### PR TITLE
docs: document installation with Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ The server can be installed via `cargo` (or from source).
 cargo install beancount-language-server
 ```
 
+Alternatively, it can be installed via Homebrew.
+
+```sh
+brew install beancount-language-server
+```
+
 Then, you should be able to run the language server with the following command:
 
 ```sh


### PR DESCRIPTION
I've packaged beancount-language-server for Homebrew in https://github.com/Homebrew/homebrew-core/pull/168951.