### PR TITLE
fix: change message prefix from mun to beancount

### DIFF
--- a/crates/lsp/src/progress.rs
+++ b/crates/lsp/src/progress.rs
@@ -30,7 +30,7 @@ impl LspServerState {
             (0.0..=1.0).contains(&f);
             (f * 100.0) as u32
         });
-        let token = lsp_types::ProgressToken::String(format!("mun/{}", title));
+        let token = lsp_types::ProgressToken::String(format!("beancount/{}", title));
         let work_done_progress = match state {
             Progress::Begin => {
                 self.send_request::<lsp_types::request::WorkDoneProgressCreate>(


### PR DESCRIPTION
This previously referenced mun, based on
https://github.com/mun-lang/mun/blob/45b92db41bc54e201929a322dc2dd16441d34380/crates/mun_language_server/src/state/utils.rs#L42.