### PR TITLE
Fix: cargo install

### DIFF
--- a/crates/lsp/src/server.rs
+++ b/crates/lsp/src/server.rs
@@ -285,7 +285,7 @@ impl LspServerState {
 
     // Sends a response to the client. This method logs the time it took us to reply to a request from the client.
     pub(crate) fn respond(&mut self, response: lsp_server::Response) {
-        if let Some((_method, start)) = self.req_queue.incoming.complete(response.id.clone()) {
+        if let Some((_method, start)) = self.req_queue.incoming.complete(&response.id.clone()) {
             let duration = start.elapsed();
             tracing::info!("handled req#{} in {:?}", response.id, duration);
             self.send(response.into());


### PR DESCRIPTION
I got this while installing `beancount-language-sever`
```
error[E0308]: mismatched types
--> /home/valtrois/.cargo/registry/src/index.crates.io-6f17d22bba15001f/beancount-language-server-1.3.5/src/server.rs:288:74
if let Some((_method, start)) = self.req_queue.incoming.complete(response.id.clone()) {
                                                                 ^^^^^^^^^^^^^^^^^^^
expected `&RequestId`, found `RequestId`
arguments to this method are incorrect
```