### PR TITLE
chore: fix cargo lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "beancount-language-server"
-version = "1.3.6"
+version = "1.3.7"
 dependencies = [
  "anyhow",
  "bytes",


### PR DESCRIPTION
Fixes cargo.lock
Should be enough for cargo build --locked. #610 is not necessary.