### PR TITLE
chore: ignore @types/node dependency in dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,9 @@ updates:
       prefix: "chore:"
     labels:
       - dependabot
+    ignore:
+      # vscode doesn't use latest node
+      - dependency-name: "@types/node"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
The vscode don't use latest nodejs, it should not be updated automatically