### PR TITLE
fix: remove invalid 'workflows' permission from dependabot-automerge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  workflows: write
 
 jobs:
   enable-auto-merge:


### PR DESCRIPTION
The 'workflows: write' permission is not a valid GitHub Actions permission and causes the workflow to fail with a syntax error.

Valid permissions are: actions, checks, contents, deployments, id-token, issues, discussions, packages, pages, pull-requests, repository-projects, security-events, statuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)