### PR TITLE
feat: send error message on non-existant root

### DIFF
--- a/crates/lsp/src/server.rs
+++ b/crates/lsp/src/server.rs
@@ -134,6 +134,12 @@ impl LspServerState {
 
             // Check if exists
             if !journal_root.exists() {
+                self.send_notification::<lsp_types::notification::ShowMessage>(
+                    lsp_types::ShowMessageParams {
+                        typ: lsp_types::MessageType::ERROR,
+                        message: format!("Journal root does not exist: {}", journal_root.display()),
+                    },
+                );
                 tracing::error!("Journal root does not exist: {}", journal_root.display());
                 return Err(anyhow::anyhow!(
                     "Journal root does not exist: {}",


### PR DESCRIPTION
It's annoying when tools silently fail, due to e.g. a typo in the json key.
With this change it's obvious what the issue is, without looking into lsp logs.