### PR TITLE
chore: set lsp request logging to trace level

### DIFF
--- a/crates/lsp/src/server.rs
+++ b/crates/lsp/src/server.rs
@@ -366,7 +366,7 @@ impl LspServerState {
                     response.error
                 );
             } else {
-                tracing::info!(
+                tracing::trace!(
                     "Request {} ({}) completed successfully in {:?}",
                     response.id,
                     method,


### PR DESCRIPTION
forget one request