### PR TITLE
fix(bean-check): improve error handling and diagnostics for Windows paths

### DIFF
--- a/crates/lsp/src/providers/diagnostics.rs
+++ b/crates/lsp/src/providers/diagnostics.rs
@@ -49,7 +49,7 @@ pub fn diagnostics(
     checker: &dyn BeancountChecker,
     root_journal_file: &Path,
 ) -> HashMap<PathBuf, Vec<lsp_types::Diagnostic>> {
-    tracing::info!("Starting diagnostics for: {}", root_journal_file.display());
+    tracing::trace!("Starting diagnostics for: {}", root_journal_file.display());
     tracing::debug!("Using checker: {}", checker.name());
     tracing::debug!(
         "Processing beancount data for {} files",
@@ -119,16 +119,8 @@ fn convert_errors_to_diagnostics(
             error.line.saturating_sub(1)
         };
 
-        let position = lsp_types::Position {
-            line: line_number,
-            character: 0, // Start of line (bean-check doesn't provide column info)
-        };
-
         let diagnostic = lsp_types::Diagnostic {
-            range: lsp_types::Range {
-                start: position,
-                end: position, // Point diagnostic
-            },
+            range: full_line_range(line_number),
             message: error.message,
             severity: Some(lsp_types::DiagnosticSeverity::ERROR),
             source: Some("bean-check".to_string()),
@@ -148,6 +140,17 @@ fn convert_errors_to_diagnostics(
     diagnostics_map
 }
 
+/// Build a full-line range starting at column 0 to a very large column value.
+fn full_line_range(line: u32) -> lsp_types::Range {
+    lsp_types::Range {
+        start: lsp_types::Position { line, character: 0 },
+        end: lsp_types::Position {
+            line,
+            character: u32::MAX,
+        },
+    }
+}
+
 /// Merge flagged entries from checker into diagnostics map.
 fn merge_flagged_entries_from_checker(
     diagnostics_map: &mut HashMap<PathBuf, Vec<lsp_types::Diagnostic>>,
@@ -161,16 +164,8 @@ fn merge_flagged_entries_from_checker(
             entry.line.saturating_sub(1)
         };
 
-        let position = lsp_types::Position {
-            line: line_number,
-            character: 0,
-        };
-
         let diagnostic = lsp_types::Diagnostic {
-            range: lsp_types::Range {
-                start: position,
-                end: position,
-            },
+            range: full_line_range(line_number),
             message: entry.message,
             severity: Some(lsp_types::DiagnosticSeverity::WARNING),
             source: Some("bean-check".to_string()),
@@ -194,16 +189,8 @@ fn merge_flagged_entries_from_parsed_data(
 ) {
     for (file_path, data) in beancount_data.iter() {
         for flagged_entry in &data.flagged_entries {
-            let position = lsp_types::Position {
-                line: flagged_entry.line,
-                character: 0, // Start of line
-            };
-
             let diagnostic = lsp_types::Diagnostic {
-                range: lsp_types::Range {
-                    start: position,
-                    end: position,
-                },
+                range: full_line_range(flagged_entry.line),
                 message: "Transaction flagged for review".to_string(),
                 severity: Some(lsp_types::DiagnosticSeverity::WARNING),
                 source: Some("beancount-lsp".to_string()),

--- a/crates/lsp/src/providers/formatting.rs
+++ b/crates/lsp/src/providers/formatting.rs
@@ -95,7 +95,7 @@ pub(crate) fn formatting(
     snapshot: LspServerStateSnapshot,
     params: lsp_types::DocumentFormattingParams,
 ) -> Result<Option<Vec<lsp_types::TextEdit>>> {
-    tracing::info!(
+    tracing::trace!(
         "Starting formatting for document: {}",
         params.text_document.uri.as_str()
     );


### PR DESCRIPTION
the bean-check check is broken on windows, with path `"C:\\path\\to\\file.bean"`

and I send a PR to add `--json` flag to `bean-check`, which will make it easier for us to parse errors in the future.