### PR TITLE
build: enable abi3 feature of pyo3

### DIFF
--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -56,6 +56,7 @@ rust_decimal = "1.37"
 
 # Python integration (optional)
 pyo3 = { version = "0.27", features = [
+    "abi3-py38",
     "auto-initialize",
     "generate-import-lib"
 ], optional = true }


### PR DESCRIPTION
without abi3 feature, the executable link to a minor version or python (python3.X.so, shipped with python3.X only), which means if you build pyo3 with python3.14, the users also need to use python3.14. 

If abi3-py38 enabled, you can build pyo3 with any python >= 3.8, it only link to python3.so which is shipped by all python3, and the executable works with any python >= 3.8.