### PR TITLE
docs: add troubleshooting tips for inlay hints in VSCode

### DIFF
--- a/vscode/README.md
+++ b/vscode/README.md
@@ -48,6 +48,16 @@ Key options:
 - Make sure Python and the `beancount` package are available in the same environment VS Code uses.
 - If diagnostics do not appear, ensure `beancountLangServer.journalFile` is set and run `bean-check` (or your configured command) in a VS Code terminal to confirm it works there.
 
+- VSCode has some trouble supporting inlay-hints, you can disable it in settings:
+
+```json
+{
+  "[beancount]": {
+    "editor.inlayHints.enabled": "off"
+  }
+}
+```
+
 ## Develop the extension
 
 ```bash


### PR DESCRIPTION
vscode has poor support for inlay hints.

It display it correctly but if you try to edit lines with inlay hint you will find your cursor fly to unexpected posotion

I don't know if it happens in other editor, let's suggest to disable in vscode.

![屏幕录制 2026-01-17 202017](https://github.com/user-attachments/assets/e2ebe4a9-554a-4963-b77d-346017bc048a)

Another idea is to put this in hover.

Also, we already have diagnostics, why yet another warning for Unbalanced Transfer?
