### PR TITLE
feat: add configurable cross-segment fuzzy matching for account completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,9 @@ The language server accepts configuration via LSP initialization options:
     "account_amount_spacing": 2,
     "number_currency_spacing": 1
   },
+  "completion": {
+    "fuzzy_match_accounts": true  // Optional: cross-segment fuzzy matching (default: false)
+  },
   "diagnostic_flags": ["!"]  // Optional: flags that generate warnings (default: ["!"])
 }
 ```
@@ -492,6 +495,24 @@ This controls the whitespace between numbers and currency codes:
 }
 ```
 
+### Completion Options
+
+| Option                              | Type    | Description                                                                                                  | Default |
+| ----------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------ | ------- |
+| `completion.fuzzy_match_accounts`   | boolean | Enable cross-segment fuzzy matching for account completions. When enabled, typing "BankCheck" can match "Assets:US:Bank:Checking" without typing each segment hierarchically. | `false` |
+
+**Disable cross-segment fuzzy matching:**
+
+```json
+{
+  "completion": {
+    "fuzzy_match_accounts": false
+  }
+}
+```
+
+When disabled, account completions use standard prefix matching only (e.g., you must type "Assets:US:Bank" to match accounts under that path).
+
 ## 🖥️ Editor Setup
 
 ### Visual Studio Code
@@ -538,6 +559,10 @@ return {
         journal_file = "main.bean",
         -- Optional: flags that generate warnings (default: ["!"])
         diagnostic_flags = { "!" },
+        -- Optional: completion behavior
+        completion = {
+            fuzzy_match_accounts = true, -- cross-segment fuzzy matching (default: false)
+        },
     },
     settings = {
         beancount = {
@@ -566,6 +591,10 @@ lspconfig.beancount.setup({
       currency_column = 60,
       number_currency_spacing = 1,
     },
+    -- Optional: completion behavior
+    -- completion = {
+    --   fuzzy_match_accounts = true, -- cross-segment fuzzy matching (default: false)
+    -- },
     -- Optional: flags that generate warnings (default: {"!"})
     diagnostic_flags = { "!" },
   },
@@ -632,6 +661,10 @@ args = ["--stdio"]
 # [language-server.beancount-language-server.config.bean_check]
 # method = "python-embedded"  # or "python-system" or "system"
 
+# Optional: completion behavior
+# [language-server.beancount-language-server.config.completion]
+# fuzzy_match_accounts = true  # cross-segment fuzzy matching (default: false)
+
 # Optional: formatting configuration
 [language-server.beancount-language-server.config.formatting]
 prefix_width = 30
@@ -662,6 +695,10 @@ Add to your `settings.json` (access via `Zed > Settings > Open Settings`):
           "prefix_width": 30,
           "currency_column": 60,
           "number_currency_spacing": 1
+        },
+        // Optional: completion behavior
+        "completion": {
+          "fuzzy_match_accounts": true  // cross-segment fuzzy matching (default: true)
         }
       }
     }
@@ -710,6 +747,8 @@ Using [lsp-mode](https://github.com/emacs-lsp/lsp-mode):
                 ;; :journal_file "/path/to/main.beancount"
                 ;; Optional: bean_check config (uses python-embedded by default)
                 ;; :bean_check '(:method "python-embedded")
+                ;; Optional: completion behavior
+                ;; :completion '(:fuzzy_match_accounts t)
                 :formatting '(:prefix_width 30 :currency_column 60 :number_currency_spacing 1))))))
 ```
 
@@ -780,7 +819,11 @@ Add to LSP settings:
           "prefix_width": 30,
           "currency_column": 60,
           "number_currency_spacing": 1
-        }
+        },
+        // Optional: completion behavior
+        // "completion": {
+        //   "fuzzy_match_accounts": true
+        // }
       }
     }
   }

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -11,6 +11,7 @@ pub struct Config {
     /// path to root journal file
     pub journal_root: Option<PathBuf>,
     pub formatting: FormattingConfig,
+    pub completion: CompletionConfig,
     pub bean_check: BeancountCheckConfig,
     /// Flags that should generate diagnostics (e.g., ["!"] for only exclamation mark)
     pub diagnostic_flags: Vec<String>,
@@ -57,12 +58,28 @@ impl FormattingConfig {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct CompletionConfig {
+    /// Enable cross-segment fuzzy matching for account completions.
+    /// When true, typing "BankCheck" can match "Assets:US:Bank:Checking".
+    pub fuzzy_match_accounts: bool,
+}
+
+impl CompletionConfig {
+    pub fn default() -> Self {
+        Self {
+            fuzzy_match_accounts: false,
+        }
+    }
+}
+
 impl Config {
     pub fn new(root_dir: PathBuf) -> Self {
         Self {
             root_dir,
             journal_root: None,
             formatting: FormattingConfig::default(),
+            completion: CompletionConfig::default(),
             bean_check: BeancountCheckConfig::new(),
             diagnostic_flags: vec!["!".to_string()],
         }
@@ -129,6 +146,13 @@ impl Config {
             }
         }
 
+        // Update completion configuration
+        if let Some(completion) = beancount_lsp_settings.completion
+            && let Some(fuzzy) = completion.fuzzy_match_accounts
+        {
+            self.completion.fuzzy_match_accounts = fuzzy;
+        }
+
         // Update diagnostic_flags configuration
         if let Some(diagnostic_flags) = beancount_lsp_settings.diagnostic_flags {
             self.diagnostic_flags = diagnostic_flags;
@@ -142,6 +166,7 @@ impl Config {
 pub struct BeancountLspOptions {
     pub journal_file: Option<String>,
     pub formatting: Option<FormattingOptions>,
+    pub completion: Option<CompletionOptions>,
     pub bean_check: Option<BeancountCheckOptions>,
     /// Flags that should generate diagnostics (e.g., ["!"] for only exclamation mark)
     pub diagnostic_flags: Option<Vec<String>>,
@@ -166,6 +191,12 @@ pub struct FormattingOptions {
 
     /// Enforce consistent indentation width for postings and directives.
     pub indent_width: Option<usize>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct CompletionOptions {
+    /// Enable cross-segment fuzzy matching for account completions.
+    pub fuzzy_match_accounts: Option<bool>,
 }
 
 #[serde_as]
@@ -525,5 +556,31 @@ mod tests {
             .update(serde_json::from_str(r#"{"diagnostic_flags": []}"#).unwrap())
             .unwrap();
         assert_eq!(config.diagnostic_flags, Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_completion_config_default() {
+        let config = Config::new(PathBuf::new());
+        assert!(!config.completion.fuzzy_match_accounts);
+    }
+
+    #[test]
+    fn test_completion_fuzzy_match_disabled() {
+        let mut config = Config::new(PathBuf::new());
+        config
+            .update(
+                serde_json::from_str(r#"{"completion": {"fuzzy_match_accounts": false}}"#).unwrap(),
+            )
+            .unwrap();
+        assert!(!config.completion.fuzzy_match_accounts);
+    }
+
+    #[test]
+    fn test_completion_fuzzy_match_omitted_preserves_default() {
+        let mut config = Config::new(PathBuf::new());
+        config
+            .update(serde_json::from_str(r#"{"completion": {}}"#).unwrap())
+            .unwrap();
+        assert!(!config.completion.fuzzy_match_accounts);
     }
 }

--- a/crates/lsp/src/providers/completion.rs
+++ b/crates/lsp/src/providers/completion.rs
@@ -102,7 +102,13 @@ pub(crate) fn completion(
     debug!("Determined context: {:?}", context);
 
     // Generate completions based on context
-    generate_completions(&snapshot.beancount_data, &context, content, cursor.position)
+    generate_completions(
+        &snapshot.beancount_data,
+        &context,
+        content,
+        cursor.position,
+        &snapshot.config,
+    )
 }
 
 /// Determine completion context using left-context-aware traversal.
@@ -632,6 +638,7 @@ fn generate_completions(
     context: &CompletionContext,
     content: &ropey::Rope,
     position: Position,
+    config: &crate::config::Config,
 ) -> Result<Option<Vec<CompletionItem>>> {
     match context {
         CompletionContext::DocumentRoot => {
@@ -650,23 +657,35 @@ fn generate_completions(
             data, "", content, position, false,
         )?)),
 
-        CompletionContext::PostingAccount { prefix } => {
-            Ok(Some(complete_account(data, prefix, content, position)?))
-        }
+        CompletionContext::PostingAccount { prefix } => Ok(Some(complete_account(
+            data,
+            prefix,
+            content,
+            position,
+            config.completion.fuzzy_match_accounts,
+        )?)),
 
         CompletionContext::PostingAmount => Ok(Some(complete_amount()?)),
 
         CompletionContext::PostingCurrency => Ok(Some(complete_currency(data, content, position)?)),
 
-        CompletionContext::OpenAccount { prefix } => {
-            Ok(Some(complete_account(data, prefix, content, position)?))
-        }
+        CompletionContext::OpenAccount { prefix } => Ok(Some(complete_account(
+            data,
+            prefix,
+            content,
+            position,
+            config.completion.fuzzy_match_accounts,
+        )?)),
 
         CompletionContext::OpenCurrency => Ok(Some(complete_currency(data, content, position)?)),
 
-        CompletionContext::BalanceAccount { prefix } => {
-            Ok(Some(complete_account(data, prefix, content, position)?))
-        }
+        CompletionContext::BalanceAccount { prefix } => Ok(Some(complete_account(
+            data,
+            prefix,
+            content,
+            position,
+            config.completion.fuzzy_match_accounts,
+        )?)),
 
         CompletionContext::PriceContext => Ok(Some(complete_currency(data, content, position)?)),
 
@@ -795,6 +814,7 @@ fn complete_account(
     prefix: &str,
     content: &ropey::Rope,
     position: Position,
+    fuzzy_filter: bool,
 ) -> Result<Vec<CompletionItem>> {
     let mut all_accounts: Vec<String> = Vec::new();
 
@@ -817,15 +837,22 @@ fn complete_account(
         .into_iter()
         .take(50)
         .map(|(account, score)| {
-            create_completion_with_insert_replace(
-                account,
+            let mut item = create_completion_with_insert_replace(
+                account.clone(),
                 "Beancount Account".to_string(),
                 CompletionItemKind::ENUM,
                 insert_range,
                 replace_range,
                 score,
                 vec![":".to_string()], // Commit character for flow
-            )
+            );
+            if fuzzy_filter {
+                // Append colon-stripped version so client-side fuzzy matchers
+                // can match cross-segment queries like "BankCheck"
+                let stripped = account.replace(':', "");
+                item.filter_text = Some(format!("{} {}", account, stripped));
+            }
+            item
         })
         .collect())
 }
@@ -3143,6 +3170,83 @@ option "name_expenses" "Aufwendungen"
             aktiva_pos.unwrap() < 3,
             "Aktiva:Bank should be ranked in top 3 for prefix 'Akti', found at position {:?}",
             aktiva_pos
+        );
+    }
+
+    // ========================================================================
+    // Account Completion filter_text Tests
+    // ========================================================================
+
+    #[test]
+    fn test_complete_account_fuzzy_filter_sets_filter_text() {
+        use ropey::Rope;
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+        use std::sync::Arc;
+
+        let test_data = r#"
+2026-01-01 open Assets:US:Bank:Checking
+2026-01-01 open Expenses:Food:Groceries
+"#;
+
+        let mut data_map = HashMap::new();
+        let bean_data = create_test_beancount_data(test_data);
+        data_map.insert(PathBuf::from("test.bean"), Arc::new(bean_data));
+
+        let content = Rope::from_str("  Assets");
+        let position = Position {
+            line: 0,
+            character: 8,
+        };
+
+        let items = complete_account(&data_map, "Assets", &content, position, true).unwrap();
+
+        let checking = items.iter().find(|i| i.label == "Assets:US:Bank:Checking");
+        assert!(checking.is_some(), "Should find Assets:US:Bank:Checking");
+
+        // With fuzzy_filter=true, filter_text should contain both the original and stripped version
+        let ft = checking.unwrap().filter_text.as_ref().unwrap();
+        assert!(
+            ft.contains("Assets:US:Bank:Checking"),
+            "filter_text should contain the original account"
+        );
+        assert!(
+            ft.contains("AssetsUSBankChecking"),
+            "filter_text should contain the colon-stripped version for cross-segment matching"
+        );
+    }
+
+    #[test]
+    fn test_complete_account_no_fuzzy_filter_preserves_default_filter_text() {
+        use ropey::Rope;
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+        use std::sync::Arc;
+
+        let test_data = r#"
+2026-01-01 open Assets:US:Bank:Checking
+"#;
+
+        let mut data_map = HashMap::new();
+        let bean_data = create_test_beancount_data(test_data);
+        data_map.insert(PathBuf::from("test.bean"), Arc::new(bean_data));
+
+        let content = Rope::from_str("  Assets");
+        let position = Position {
+            line: 0,
+            character: 8,
+        };
+
+        let items = complete_account(&data_map, "Assets", &content, position, false).unwrap();
+
+        let checking = items.iter().find(|i| i.label == "Assets:US:Bank:Checking");
+        assert!(checking.is_some(), "Should find Assets:US:Bank:Checking");
+
+        // With fuzzy_filter=false, filter_text should be the default (label), not the augmented version
+        let ft = checking.unwrap().filter_text.as_ref().unwrap();
+        assert!(
+            !ft.contains("AssetsUSBankChecking"),
+            "filter_text should NOT contain the colon-stripped version when fuzzy is off"
         );
     }
 }

--- a/docs/completion-system.md
+++ b/docs/completion-system.md
@@ -28,8 +28,11 @@ Instead of overwhelming you with every possible completion, the system provides 
 
 ### Account Completions
 - **Trigger**: Typing in posting areas or after `:`
-- **Features**: 
+- **Features**:
   - Fuzzy search with nucleo-matcher (6x faster than alternatives)
+  - Cross-segment fuzzy matching (configurable via `completion.fuzzy_match_accounts`):
+    - `BankCheck` → Matches "Assets:US:Bank:Checking" across segments
+    - `SavRetire` → Matches "Assets:Savings:Retirement" without typing each segment
   - Capitalization-based filtering:
     - `A` → All accounts starting with "A" (Assets:*, Accounts:*)
     - `a` → Fuzzy search across all accounts

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -110,6 +110,20 @@
             }
           }
         },
+        "beancountLangServer.completion": {
+          "scope": "resource",
+          "description": "Completion behavior options",
+          "type": "object",
+          "default": {},
+          "additionalProperties": true,
+          "properties": {
+            "fuzzy_match_accounts": {
+              "type": "boolean",
+              "default": false,
+              "description": "Enable cross-segment fuzzy matching for account completions. When enabled, typing 'BankCheck' can match 'Assets:US:Bank:Checking'."
+            }
+          }
+        },
         "beancountLangServer.beanCheck": {
           "scope": "resource",
           "description": "Bean-check execution options",


### PR DESCRIPTION
Append a colon-stripped version of the account name to filter_text so client-side fuzzy matchers can match queries like "BankCheck" against "Assets:US:Bank:Checking" without requiring hierarchical typing.

Add completion.fuzzy_match_accounts setting (default: false) to allow users to enable or disable this behavior via their LSP client config.